### PR TITLE
Improve compatibility of start.ps1 with GenisysPro

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -9,12 +9,21 @@ if(Test-Path "bin\php\php.exe"){
 	$binary = "php"
 }
 
-if(Test-Path "PocketMine-MP.phar"){
+if(Test-Path "Genisys*.phar"){
+    # Windows PowerShell does not recognize file path with wildcard,
+    # so we need to get the exact file path.
+    foreach($filename in Get-ChildItem Genisys*.phar -Name){
+        $file = "'$filename'" # This allows the file name to contain space
+        break
+    }
+}elseif(Test-Path "PocketMine-MP.phar"){
 	$file = "PocketMine-MP.phar"
 }elseif(Test-Path "src\pocketmine\PocketMine.php"){
 	$file = "src\pocketmine\PocketMine.php"
+}elseif(Test-Path "Genisys.phar"){
+	$file = "Genisys.phar"
 }else{
-	echo "Couldn't find a valid PocketMine-MP installation"
+	echo "[ERROR] Couldn't find a valid Genisys installation."
 	pause
 	exit 1
 }


### PR DESCRIPTION
### Description
The original Windows PowerShell script `start.ps1` only works with file name `PocketMine-MP.phar`. However, this pull request allows the script to work with `Genisys*.phar` and `Genisys.phar` also.  
To keep consistency with the current `start.cmd`, I did not use `GenisysPro.phar` or something like that. Nevertheless, `Genisys*.phar` still works with GenisysPro, so that should not be a problem.

原来的 Windows Powershell 脚本 `start.ps1` 只能识别 `PocketMine-MP.phar`，而我这个PR可以让它同时识别 `Genisys*.phar` 和 `Genisys.phar`。  
为了和 `start.cmd` 保持一致，我没用 `GenisysPro.phar` 之类的文件名。不过没有影响，因为 `Genisys*.phar` 已经可以涵盖 GenisysPro。

### Reason to modify
The default file name of GenisysPro artifact using `/ms` command is `GenisysPro_.phar`. The current `start.ps1` does not support it, which is quite inconvenient.  
Also, to make `start.ps1` consistent with `start.cmd`, I also changed the error message when a valid GenisysPro installation is not found.

在 GenisysPro 里使用 `/ms` 命令生成的核心的默认文件名是 `GenisysPro_.phar`，然而目前的 `start.ps1` 并不支持此文件名，造成不便。  
并且，为了和 `start.cmd` 保持一致，我还修改了找不到有效的 GenisysPro 文件时提示的错误信息。


### Tests & Reviews
I have tested the code and it works. More tests are welcomed.  
我已测试过新代码，未遇到问题。也欢迎更多的人测试。