### PR TITLE
Add MCPACK resource pack support

### DIFF
--- a/src/pocketmine/resourcepacks/ResourcePackManager.php
+++ b/src/pocketmine/resourcepacks/ResourcePackManager.php
@@ -89,6 +89,9 @@ class ResourcePackManager{
 							case "zip":
 								$newPack = new ZippedResourcePack($packPath);
 								break;
+							case "mcpack":
+								$newPack = new ZippedResourcePack($packPath);
+								break;
 							default:
 								$this->server->getLogger()->warning($this->server->getLanguage()->translateString("pocketmine.resourcepacks.unsupportedType", [$path]));
 								break;


### PR DESCRIPTION
### Description
This pull request would add support for MCPACK resource packs.

### Reason to modify
I think the only difference between MCPACK format and ZIP format for resource pack is the file extension. The evidence is that you can change an MCPACK file's extension to "zip" and open it normally with your unzip software.  
Although end users can easily change those MCPACK resource packs' file extension to "zip", so the packs work with GenisysPro, this commit will of course make adding an MCPACK resource pack **more** convenient.

### Tests & Reviews
I have tested the code with several MCPACK resource packs and it works. However, I will be pleased to hear more people reporting that this works with different resource packs.  
Therefore, you may test this change against your MCPACK resource packs and report your result. I appreciate help from everyone who tests the code!