### PR TITLE
Temporal Change To Prevent Thorns Armor Dupe

### DIFF
--- a/src/pocketmine/event/entity/EntityDamageEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageEvent.php
@@ -318,7 +318,8 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 			$this->thornsArmor = array_rand($this->thornsLevel);
 			$thornsL = $this->thornsLevel[$this->thornsArmor];
 			if(mt_rand(1, 100) < $thornsL * 15){
-				$this->thornsDamage = mt_rand(1, 4);
+				//$this->thornsDamage = mt_rand(1, 4); 
+				$this->thornsDamage = 0; //Delete When #321 Is Fixed And Add In The Normal Damage
 			}
 		}
 	}


### PR DESCRIPTION
### Description
<!-- What's this PR for? -->
To temporarily prevent players from duping using thorns armor.
This does NOT fix the glitch.

### Reason to modify
<!-- 
- Think twice before modifying: is it the best way? will it break things? 
- Have you made sure that there is actually a problem before trying to fix it?
- Explain the logic behind your changes - WHY and HOW what you have done works
-->

### Tests & Reviews
<!-- Uncomment based on the situation -->

I have tested the code and it works

<!-- Please review things below: -->
