### PR TITLE
Fix #782 - Disappearing FloatingTextParticle bug

### DIFF
--- a/src/pocketmine/level/particle/FloatingTextParticle.php
+++ b/src/pocketmine/level/particle/FloatingTextParticle.php
@@ -22,10 +22,11 @@
 namespace pocketmine\level\particle;
 
 use pocketmine\entity\Entity;
-use pocketmine\entity\Item as ItemEntity;
+use pocketmine\item\Item;
 use pocketmine\math\Vector3;
-use pocketmine\network\mcpe\protocol\AddEntityPacket;
+use pocketmine\network\mcpe\protocol\AddPlayerPacket;
 use pocketmine\network\mcpe\protocol\RemoveEntityPacket;
+use pocketmine\utils\UUID;
 
 class FloatingTextParticle extends Particle {
 	//TODO: HACK!
@@ -105,17 +106,14 @@ class FloatingTextParticle extends Particle {
 
 		if(!$this->invisible){
 
-			$pk = new AddEntityPacket();
+			$pk = new AddPlayerPacket();
+			$pk->uuid = UUID::fromRandom();
+			$pk->username = $this->title;
 			$pk->eid = $this->entityId;
-			$pk->type = ItemEntity::NETWORK_ID;
 			$pk->x = $this->x;
-			$pk->y = $this->y - 0.75;
+			$pk->y = $this->y - 0.50;
 			$pk->z = $this->z;
-			$pk->speedX = 0;
-			$pk->speedY = 0;
-			$pk->speedZ = 0;
-			$pk->yaw = 0;
-			$pk->pitch = 0;
+			$pk->item = Item::get(Item::AIR);
 			$flags = (
 				(1 << Entity::DATA_FLAG_CAN_SHOW_NAMETAG) |
 				(1 << Entity::DATA_FLAG_ALWAYS_SHOW_NAMETAG) |


### PR DESCRIPTION
### Purpose and Effect of This Pull Request
This PR Makes FloatingTextParticle.php spawn an Invisible player Instead of an ItemEntity (which... Despawns after a few mins)

### Testing
use this code: (or any other Floating Text plugin you have)
```php
// This code was taken from MY "TESTERPLUGIN" Which I use for short tests and is Written on Notepad++... (Too Lazy to open PHPStorm just to code short stuff.)
// $p = A player....
$level = $p->getLevel();
$pos = $p->getPosition();
$level->addParticle(new FloatingTextParticle($pos->add(0.5, 0.0, 0.5),"LOL",  "lolcow"));
// This code was taken from MY "TESTERPLUGIN" Which I use for short tests and is Written on Notepad++... (Too Lazy to open PHPStorm just to code short stuff.)
```
