### PR TITLE
Update to PHP7.2

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -94,8 +94,8 @@ namespace pocketmine {
 		@define('pocketmine\PATH', \getcwd() . DIRECTORY_SEPARATOR);
 	}
 
-	if(version_compare("7.0", PHP_VERSION) > 0){
-		echo "[CRITICAL] You must use PHP >= 7.0" . PHP_EOL;
+	if(version_compare("7.2", PHP_VERSION) > 0){
+		echo "[CRITICAL] You must use PHP >= 7.2" . PHP_EOL;
 		echo "[CRITICAL] Please use the installer provided on the homepage." . PHP_EOL;
 		exit(1);
 	}

--- a/src/pocketmine/Thread.php
+++ b/src/pocketmine/Thread.php
@@ -71,7 +71,7 @@ abstract class Thread extends \Thread {
 	 *
 	 * @return bool
 	 */
-	public function start(int $options = PTHREADS_INHERIT_ALL){
+	public function start(?int $options = \PTHREADS_INHERIT_ALL){
 		ThreadManager::getInstance()->add($this);
 
 		if(!$this->isRunning() and !$this->isJoined() and !$this->isTerminated()){

--- a/src/pocketmine/Worker.php
+++ b/src/pocketmine/Worker.php
@@ -72,7 +72,7 @@ abstract class Worker extends \Worker {
 	 *
 	 * @return bool
 	 */
-	public function start(int $options = PTHREADS_INHERIT_ALL){
+	public function start(?int $options = \PTHREADS_INHERIT_ALL){
 		ThreadManager::getInstance()->add($this);
 
 		if(!$this->isRunning() and !$this->isJoined() and !$this->isTerminated()){


### PR DESCRIPTION
Removes backwards compatibility for PHP7.0 and 7.1, I'm only creating this PR due to EnderCrate (hosting) using this software but we force 7.2 like PocketMine. So if you want happy people, accept this pr.