### PR TITLE
Mirror packets from old Directory structure

### DIFF
--- a/src/pocketmine/network/protocol/AddEntityPacket.php
+++ b/src/pocketmine/network/protocol/AddEntityPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\AddEntityPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\AddEntityPacket as Original; 
+
+class AddEntityPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/AddHangingEntityPacket.php
+++ b/src/pocketmine/network/protocol/AddHangingEntityPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\AddHangingEntityPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\AddHangingEntityPacket as Original; 
+
+class AddHangingEntityPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/AddItemEntityPacket.php
+++ b/src/pocketmine/network/protocol/AddItemEntityPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\AddItemEntityPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\AddItemEntityPacket as Original; 
+
+class AddItemEntityPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/AddItemPacket.php
+++ b/src/pocketmine/network/protocol/AddItemPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\AddItemPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\AddItemPacket as Original; 
+
+class AddItemPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/AddPaintingPacket.php
+++ b/src/pocketmine/network/protocol/AddPaintingPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\AddPaintingPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\AddPaintingPacket as Original; 
+
+class AddPaintingPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/AddPlayerPacket.php
+++ b/src/pocketmine/network/protocol/AddPlayerPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\AddPlayerPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\AddPlayerPacket as Original; 
+
+class AddPlayerPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/AdventureSettingsPacket.php
+++ b/src/pocketmine/network/protocol/AdventureSettingsPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\AdventureSettingsPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\AdventureSettingsPacket as Original; 
+
+class AdventureSettingsPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/AnimatePacket.php
+++ b/src/pocketmine/network/protocol/AnimatePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\AnimatePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\AnimatePacket as Original; 
+
+class AnimatePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/AvailableCommandsPacket.php
+++ b/src/pocketmine/network/protocol/AvailableCommandsPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\AvailableCommandsPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\AvailableCommandsPacket as Original; 
+
+class AvailableCommandsPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/BatchPacket.php
+++ b/src/pocketmine/network/protocol/BatchPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\BatchPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\BatchPacket as Original; 
+
+class BatchPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/BlockEntityDataPacket.php
+++ b/src/pocketmine/network/protocol/BlockEntityDataPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\BlockEntityDataPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\BlockEntityDataPacket as Original; 
+
+class BlockEntityDataPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/BlockEventPacket.php
+++ b/src/pocketmine/network/protocol/BlockEventPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\BlockEventPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\BlockEventPacket as Original; 
+
+class BlockEventPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/BlockPickRequestPacket.php
+++ b/src/pocketmine/network/protocol/BlockPickRequestPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\BlockPickRequestPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\BlockPickRequestPacket as Original; 
+
+class BlockPickRequestPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/BossEventPacket.php
+++ b/src/pocketmine/network/protocol/BossEventPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\BossEventPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\BossEventPacket as Original; 
+
+class BossEventPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/CachedEncapsulatedPacket.php
+++ b/src/pocketmine/network/protocol/CachedEncapsulatedPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\CachedEncapsulatedPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\CachedEncapsulatedPacket as Original; 
+
+class CachedEncapsulatedPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/CameraPacket.php
+++ b/src/pocketmine/network/protocol/CameraPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\CameraPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\CameraPacket as Original; 
+
+class CameraPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ChangeDimensionPacket.php
+++ b/src/pocketmine/network/protocol/ChangeDimensionPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ChangeDimensionPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ChangeDimensionPacket as Original; 
+
+class ChangeDimensionPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ChunkRadiusUpdatedPacket.php
+++ b/src/pocketmine/network/protocol/ChunkRadiusUpdatedPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ChunkRadiusUpdatedPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ChunkRadiusUpdatedPacket as Original; 
+
+class ChunkRadiusUpdatedPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ClientToServerHandshakePacket.php
+++ b/src/pocketmine/network/protocol/ClientToServerHandshakePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ClientToServerHandshakePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ClientToServerHandshakePacket as Original; 
+
+class ClientToServerHandshakePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ClientboundMapItemDataPacket.php
+++ b/src/pocketmine/network/protocol/ClientboundMapItemDataPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ClientboundMapItemDataPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ClientboundMapItemDataPacket as Original; 
+
+class ClientboundMapItemDataPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/CommandBlockUpdatePacket.php
+++ b/src/pocketmine/network/protocol/CommandBlockUpdatePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\CommandBlockUpdatePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\CommandBlockUpdatePacket as Original; 
+
+class CommandBlockUpdatePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/CommandStepPacket.php
+++ b/src/pocketmine/network/protocol/CommandStepPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\CommandStepPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\CommandStepPacket as Original; 
+
+class CommandStepPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ContainerClosePacket.php
+++ b/src/pocketmine/network/protocol/ContainerClosePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ContainerClosePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ContainerClosePacket as Original; 
+
+class ContainerClosePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ContainerOpenPacket.php
+++ b/src/pocketmine/network/protocol/ContainerOpenPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ContainerOpenPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ContainerOpenPacket as Original; 
+
+class ContainerOpenPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ContainerSetContentPacket.php
+++ b/src/pocketmine/network/protocol/ContainerSetContentPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ContainerSetContentPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ContainerSetContentPacket as Original; 
+
+class ContainerSetContentPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ContainerSetDataPacket.php
+++ b/src/pocketmine/network/protocol/ContainerSetDataPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ContainerSetDataPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ContainerSetDataPacket as Original; 
+
+class ContainerSetDataPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ContainerSetSlotPacket.php
+++ b/src/pocketmine/network/protocol/ContainerSetSlotPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ContainerSetSlotPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ContainerSetSlotPacket as Original; 
+
+class ContainerSetSlotPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/CraftingDataPacket.php
+++ b/src/pocketmine/network/protocol/CraftingDataPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\CraftingDataPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\CraftingDataPacket as Original; 
+
+class CraftingDataPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/CraftingEventPacket.php
+++ b/src/pocketmine/network/protocol/CraftingEventPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\CraftingEventPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\CraftingEventPacket as Original; 
+
+class CraftingEventPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/DataPacket.php
+++ b/src/pocketmine/network/protocol/DataPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\DataPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\DataPacket as Original; 
+
+class DataPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/DisconnectPacket.php
+++ b/src/pocketmine/network/protocol/DisconnectPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\DisconnectPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\DisconnectPacket as Original; 
+
+class DisconnectPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/DropItemPacket.php
+++ b/src/pocketmine/network/protocol/DropItemPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\DropItemPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\DropItemPacket as Original; 
+
+class DropItemPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/EntityEventPacket.php
+++ b/src/pocketmine/network/protocol/EntityEventPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\EntityEventPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\EntityEventPacket as Original; 
+
+class EntityEventPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/EntityFallPacket.php
+++ b/src/pocketmine/network/protocol/EntityFallPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\EntityFallPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\EntityFallPacket as Original; 
+
+class EntityFallPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ExplodePacket.php
+++ b/src/pocketmine/network/protocol/ExplodePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ExplodePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ExplodePacket as Original; 
+
+class ExplodePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/FullChunkDataPacket.php
+++ b/src/pocketmine/network/protocol/FullChunkDataPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\FullChunkDataPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\FullChunkDataPacket as Original; 
+
+class FullChunkDataPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/HurtArmorPacket.php
+++ b/src/pocketmine/network/protocol/HurtArmorPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\HurtArmorPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\HurtArmorPacket as Original; 
+
+class HurtArmorPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/Info.php
+++ b/src/pocketmine/network/protocol/Info.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ProtocolInfo.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ProtocolInfo as Original; 
+
+class Info extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/InteractPacket.php
+++ b/src/pocketmine/network/protocol/InteractPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\InteractPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\InteractPacket as Original; 
+
+class InteractPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/InventoryActionPacket.php
+++ b/src/pocketmine/network/protocol/InventoryActionPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\InventoryActionPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\InventoryActionPacket as Original; 
+
+class InventoryActionPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ItemFrameDropItemPacket.php
+++ b/src/pocketmine/network/protocol/ItemFrameDropItemPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ItemFrameDropItemPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ItemFrameDropItemPacket as Original; 
+
+class ItemFrameDropItemPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/LevelEventPacket.php
+++ b/src/pocketmine/network/protocol/LevelEventPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\LevelEventPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\LevelEventPacket as Original; 
+
+class LevelEventPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/LevelSoundEventPacket.php
+++ b/src/pocketmine/network/protocol/LevelSoundEventPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\LevelSoundEventPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket as Original; 
+
+class LevelSoundEventPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/LoginPacket.php
+++ b/src/pocketmine/network/protocol/LoginPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\LoginPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\LoginPacket as Original; 
+
+class LoginPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/MapInfoRequestPacket.php
+++ b/src/pocketmine/network/protocol/MapInfoRequestPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\MapInfoRequestPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\MapInfoRequestPacket as Original; 
+
+class MapInfoRequestPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/MobArmorEquipmentPacket.php
+++ b/src/pocketmine/network/protocol/MobArmorEquipmentPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\MobArmorEquipmentPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\MobArmorEquipmentPacket as Original; 
+
+class MobArmorEquipmentPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/MobEffectPacket.php
+++ b/src/pocketmine/network/protocol/MobEffectPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\MobEffectPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\MobEffectPacket as Original; 
+
+class MobEffectPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/MobEquipmentPacket.php
+++ b/src/pocketmine/network/protocol/MobEquipmentPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\MobEquipmentPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\MobEquipmentPacket as Original; 
+
+class MobEquipmentPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/MoveEntityPacket.php
+++ b/src/pocketmine/network/protocol/MoveEntityPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\MoveEntityPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\MoveEntityPacket as Original; 
+
+class MoveEntityPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/MovePlayerPacket.php
+++ b/src/pocketmine/network/protocol/MovePlayerPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\MovePlayerPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\MovePlayerPacket as Original; 
+
+class MovePlayerPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/PlaySoundPacket.php
+++ b/src/pocketmine/network/protocol/PlaySoundPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\PlaySoundPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\PlaySoundPacket as Original; 
+
+class PlaySoundPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/PlayStatusPacket.php
+++ b/src/pocketmine/network/protocol/PlayStatusPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\PlayStatusPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\PlayStatusPacket as Original; 
+
+class PlayStatusPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/PlayerActionPacket.php
+++ b/src/pocketmine/network/protocol/PlayerActionPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\PlayerActionPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\PlayerActionPacket as Original; 
+
+class PlayerActionPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/PlayerInputPacket.php
+++ b/src/pocketmine/network/protocol/PlayerInputPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\PlayerInputPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\PlayerInputPacket as Original; 
+
+class PlayerInputPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/PlayerListPacket.php
+++ b/src/pocketmine/network/protocol/PlayerListPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\PlayerListPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\PlayerListPacket as Original; 
+
+class PlayerListPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ProtocolInfo.php
+++ b/src/pocketmine/network/protocol/ProtocolInfo.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ProtocolInfo.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ProtocolInfo as Original; 
+
+class ProtocolInfo extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/RakLibInterface.php
+++ b/src/pocketmine/network/protocol/RakLibInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\RakLibInterface.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\RakLibInterface as Original; 
+
+class RakLibInterface extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/RemoveBlockPacket.php
+++ b/src/pocketmine/network/protocol/RemoveBlockPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\RemoveBlockPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\RemoveBlockPacket as Original; 
+
+class RemoveBlockPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/RemoveEntityPacket.php
+++ b/src/pocketmine/network/protocol/RemoveEntityPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\RemoveEntityPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\RemoveEntityPacket as Original; 
+
+class RemoveEntityPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ReplaceItemInSlotPacket.php
+++ b/src/pocketmine/network/protocol/ReplaceItemInSlotPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ReplaceItemInSlotPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ReplaceItemInSlotPacket as Original; 
+
+class ReplaceItemInSlotPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/RequestChunkRadiusPacket.php
+++ b/src/pocketmine/network/protocol/RequestChunkRadiusPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\RequestChunkRadiusPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\RequestChunkRadiusPacket as Original; 
+
+class RequestChunkRadiusPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ResourcePackChunkDataPacket.php
+++ b/src/pocketmine/network/protocol/ResourcePackChunkDataPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ResourcePackChunkDataPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ResourcePackChunkDataPacket as Original; 
+
+class ResourcePackChunkDataPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ResourcePackChunkRequestPacket.php
+++ b/src/pocketmine/network/protocol/ResourcePackChunkRequestPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ResourcePackChunkRequestPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ResourcePackChunkRequestPacket as Original; 
+
+class ResourcePackChunkRequestPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ResourcePackClientResponsePacket.php
+++ b/src/pocketmine/network/protocol/ResourcePackClientResponsePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ResourcePackClientResponsePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ResourcePackClientResponsePacket as Original; 
+
+class ResourcePackClientResponsePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ResourcePackDataInfoPacket.php
+++ b/src/pocketmine/network/protocol/ResourcePackDataInfoPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ResourcePackDataInfoPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ResourcePackDataInfoPacket as Original; 
+
+class ResourcePackDataInfoPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ResourcePackStackPacket.php
+++ b/src/pocketmine/network/protocol/ResourcePackStackPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ResourcePackStackPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ResourcePackStackPacket as Original; 
+
+class ResourcePackStackPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ResourcePacksInfoPacket.php
+++ b/src/pocketmine/network/protocol/ResourcePacksInfoPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ResourcePacksInfoPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ResourcePacksInfoPacket as Original; 
+
+class ResourcePacksInfoPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/RespawnPacket.php
+++ b/src/pocketmine/network/protocol/RespawnPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\RespawnPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\RespawnPacket as Original; 
+
+class RespawnPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/RiderJumpPacket.php
+++ b/src/pocketmine/network/protocol/RiderJumpPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\RiderJumpPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\RiderJumpPacket as Original; 
+
+class RiderJumpPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ServerToClientHandshakePacket.php
+++ b/src/pocketmine/network/protocol/ServerToClientHandshakePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ServerToClientHandshakePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ServerToClientHandshakePacket as Original; 
+
+class ServerToClientHandshakePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/SetCommandsEnabledPacket.php
+++ b/src/pocketmine/network/protocol/SetCommandsEnabledPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\SetCommandsEnabledPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\SetCommandsEnabledPacket as Original; 
+
+class SetCommandsEnabledPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/SetDifficultyPacket.php
+++ b/src/pocketmine/network/protocol/SetDifficultyPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\SetDifficultyPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\SetDifficultyPacket as Original; 
+
+class SetDifficultyPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/SetEntityDataPacket.php
+++ b/src/pocketmine/network/protocol/SetEntityDataPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\SetEntityDataPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\SetEntityDataPacket as Original; 
+
+class SetEntityDataPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/SetEntityLinkPacket.php
+++ b/src/pocketmine/network/protocol/SetEntityLinkPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\SetEntityLinkPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\SetEntityLinkPacket as Original; 
+
+class SetEntityLinkPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/SetEntityMotionPacket.php
+++ b/src/pocketmine/network/protocol/SetEntityMotionPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\SetEntityMotionPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\SetEntityMotionPacket as Original; 
+
+class SetEntityMotionPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/SetHealthPacket.php
+++ b/src/pocketmine/network/protocol/SetHealthPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\SetHealthPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\SetHealthPacket as Original; 
+
+class SetHealthPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/SetPlayerGameTypePacket.php
+++ b/src/pocketmine/network/protocol/SetPlayerGameTypePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\SetPlayerGameTypePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\SetPlayerGameTypePacket as Original; 
+
+class SetPlayerGameTypePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/SetSpawnPositionPacket.php
+++ b/src/pocketmine/network/protocol/SetSpawnPositionPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\SetSpawnPositionPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\SetSpawnPositionPacket as Original; 
+
+class SetSpawnPositionPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/SetTimePacket.php
+++ b/src/pocketmine/network/protocol/SetTimePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\SetTimePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\SetTimePacket as Original; 
+
+class SetTimePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/SetTitlePacket.php
+++ b/src/pocketmine/network/protocol/SetTitlePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\SetTitlePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\SetTitlePacket as Original; 
+
+class SetTitlePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/ShowCreditsPacket.php
+++ b/src/pocketmine/network/protocol/ShowCreditsPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\ShowCreditsPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\ShowCreditsPacket as Original; 
+
+class ShowCreditsPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/SpawnExperienceOrbPacket.php
+++ b/src/pocketmine/network/protocol/SpawnExperienceOrbPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\SpawnExperienceOrbPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\SpawnExperienceOrbPacket as Original; 
+
+class SpawnExperienceOrbPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/StartGamePacket.php
+++ b/src/pocketmine/network/protocol/StartGamePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\StartGamePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\StartGamePacket as Original; 
+
+class StartGamePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/StopSoundPacket.php
+++ b/src/pocketmine/network/protocol/StopSoundPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\StopSoundPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\StopSoundPacket as Original; 
+
+class StopSoundPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/TakeItemEntityPacket.php
+++ b/src/pocketmine/network/protocol/TakeItemEntityPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\TakeItemEntityPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\TakeItemEntityPacket as Original; 
+
+class TakeItemEntityPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/TextPacket.php
+++ b/src/pocketmine/network/protocol/TextPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\TextPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\TextPacket as Original; 
+
+class TextPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/TransferPacket.php
+++ b/src/pocketmine/network/protocol/TransferPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\TransferPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\TransferPacket as Original; 
+
+class TransferPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/UpdateAttributesPacket.php
+++ b/src/pocketmine/network/protocol/UpdateAttributesPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\UpdateAttributesPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\UpdateAttributesPacket as Original; 
+
+class UpdateAttributesPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/UpdateBlockPacket.php
+++ b/src/pocketmine/network/protocol/UpdateBlockPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\UpdateBlockPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\UpdateBlockPacket as Original; 
+
+class UpdateBlockPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/UpdateTradePacket.php
+++ b/src/pocketmine/network/protocol/UpdateTradePacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\UpdateTradePacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\UpdateTradePacket as Original; 
+
+class UpdateTradePacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/UseItemPacket.php
+++ b/src/pocketmine/network/protocol/UseItemPacket.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\UseItemPacket.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol; 
+
+use pocketmine\network\mcpe\protocol\UseItemPacket as Original; 
+
+class UseItemPacket extends Original { 
+
+} 

--- a/src/pocketmine/network/protocol/types/InventoryNetworkIds.php
+++ b/src/pocketmine/network/protocol/types/InventoryNetworkIds.php
@@ -1,0 +1,16 @@
+<?php
+
+// ---------- CREDITS ----------
+// Mirrored from pocketmine\network\mcpe\protocol\InventoryNetworkIds.php
+// Mirroring was done by @CortexPE of @LeverylTeam :D
+// 
+// NOTE: We know that this was hacky... But It's here to still provide support for old plugins
+// ---------- CREDITS ----------
+
+namespace pocketmine\network\protocol\types; 
+
+use pocketmine\network\mcpe\protocol\types\InventoryNetworkIds as Original; 
+
+class InventoryNetworkIds extends Original { 
+
+} 


### PR DESCRIPTION
### Purpose and Effect of This Pull Request
Merging this Pull Request will provide support for old plugins that still use the ```pocketmine\network\protocol``` folder and the Info.php file instead of using the updated ones...

### Testing
Use this code in a plugin (***ADD A WAY TO EXECUTE IT OF COURSE***):
```php
// Using the OLD Directory structure...
$pk = new \pocketmine\network\protocol\LevelSoundEventPacket();
$pk->sound = \pocketmine\network\protocol\LevelSoundEventPacket::SOUND_NOTE;
$pk->x = $player->getX();
$pk->y = $player->getY();
$pk->z = $player->getZ();
$pk->extraData = 7;
$pk->pitch = 0;
$player->dataPacket($pk);
```
And you should hear a NoteBlock (Piano) sound...
If you don't, You probably should turn up the volume 😒 