### PR TITLE
Fixed wrong "extends" in ProtocolInfo

### DIFF
--- a/src/pocketmine/network/protocol/ProtocolInfo.php
+++ b/src/pocketmine/network/protocol/ProtocolInfo.php
@@ -11,6 +11,6 @@ namespace pocketmine\network\protocol;
 
 use pocketmine\network\mcpe\protocol\ProtocolInfo as Original; 
 
-class ProtocolInfo extends Original { 
+class ProtocolInfo implements Original {
 
 } 


### PR DESCRIPTION
Interfaces cannot be extended. It should be "implements".