### PR TITLE
Better Color Functions & Fix #1100

### DIFF
--- a/src/pocketmine/utils/Color.php
+++ b/src/pocketmine/utils/Color.php
@@ -1,26 +1,23 @@
 <?php
 
 /*
- *
- *  _____   _____   __   _   _   _____  __    __  _____
- * /  ___| | ____| |  \ | | | | /  ___/ \ \  / / /  ___/
- * | |     | |__   |   \| | | | | |___   \ \/ /  | |___
- * | |  _  |  __|  | |\   | | | \___  \   \  /   \___  \
- * | |_| | | |___  | | \  | | |  ___| |   / /     ___| |
- * \_____/ |_____| |_|  \_| |_| /_____/  /_/     /_____/
+ *                                  _
+ *    / /  _____   _____ _ __ _   _| |
+ *   / /  / _ \ \ / / _ \ '__| | | | |
+ *  / /__|  __/\ V /  __/ |  | |_| | |
+ *  \____/\___| \_/ \___|_|   \__, |_|
+ *                            |___/
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * @author iTX Technologies
- * @link https://itxtech.org
+ * @author LeverylTeam
+ * @link https://github.com/LeverylTeam
  *
- */
-
-/*
-* Copied from @beito123's FlowerPot plugin
+ * Merged together from BOTH Genisys and PMMP
+ *
  */
 
 namespace pocketmine\utils;
@@ -47,6 +44,7 @@ class Color {
 	private $red = 0;
 	private $green = 0;
 	private $blue = 0;
+	private $alpha = 0;
 
 	/** @var \SplFixedArray */
 	public static $dyeColors = null;
@@ -80,8 +78,8 @@ class Color {
 	 *
 	 * @return Color
 	 */
-	public static function getRGB($r, $g, $b){
-		return new Color((int) $r, (int) $g, (int) $b);
+	public static function getRGB(int $r, int $g, int $b): Color{
+		return new Color($r, $g, $b);
 	}
 
 	/**
@@ -89,7 +87,7 @@ class Color {
 	 *
 	 * @return Color
 	 */
-	public static function averageColor(Color ...$colors){
+	public static function averageColor(Color ...$colors): Color{
 		$tr = 0;//total red
 		$tg = 0;//green
 		$tb = 0;//blue
@@ -100,66 +98,146 @@ class Color {
 			$tb += $c->getBlue();
 			++$count;
 		}
+
 		return Color::getRGB($tr / $count, $tg / $count, $tb / $count);
 	}
 
 	/**
 	 * @param $id
 	 *
-	 * @return mixed|Color
+	 * @return Color
 	 */
-	public static function getDyeColor($id){
+	public static function getDyeColor($id): Color{
 		if(isset(self::$dyeColors[$id])){
 			return clone self::$dyeColors[$id];
 		}
+
 		return Color::getRGB(0, 0, 0);
 	}
 
-	/**
-	 * Color constructor.
-	 *
-	 * @param $r
-	 * @param $g
-	 * @param $b
-	 */
-	public function __construct($r, $g, $b){
+	public function __construct(int $r, int $g, int $b, int $a = 0xff){
 		$this->red = $r;
 		$this->green = $g;
 		$this->blue = $b;
+		$this->alpha = $a;
 	}
 
-	/**
-	 * @return int
-	 */
-	public function getRed(){
-		return (int) $this->red;
+	// Alpha (Transparency)
+	public function getAlpha(): int{
+		return $this->alpha;
 	}
 
-	/**
-	 * @return int
-	 */
-	public function getBlue(){
-		return (int) $this->blue;
+	public function setAlpha(int $a){
+		$this->alpha = $a;
 	}
 
-	/**
-	 * @return int
-	 */
-	public function getGreen(){
-		return (int) $this->green;
+	// Red
+	public function getRed(): int{
+		return $this->red;
 	}
 
-	/**
-	 * @return int
-	 */
+	public function setRed(int $r){
+		$this->red = $r;
+	}
+
+	// Green
+	public function getGreen(): int{
+		return $this->green;
+	}
+
+	public function setGreen(int $g){
+		$this->green = $g;
+	}
+
+	// Blue
+	public function getBlue(): int{
+		return $this->blue;
+	}
+
+	public function setBlue(int $b){
+		$this->blue = $b;
+	}
+
+	// MIRROR FUNCTIONS... JUST FOR PLUGIN COMPATIBILITY
+	public function setA(int $a){
+		$this->setAlpha($a);
+	}
+
+	public function setR(int $r){
+		$this->setRed($r);
+	}
+
+	public function setG(int $g){
+		$this->setGreen($g);
+	}
+
+	public function setB(int $b){
+		$this->setBlue($b);
+	}
+
+	public function getA(): int{
+		return $this->getAlpha();
+	}
+
+	public function getR(): int{
+		return $this->getRed();
+	}
+
+	public function getG(): int{
+		return $this->getGreen();
+	}
+
+	public function getB(): int{
+		return $this->getBlue();
+	}
+	// MIRROR FUNCTIONS... JUST FOR PLUGIN COMPATIBILITY
+
+	public static function fromRGB(int $code): Color{
+		return new Color(($code >> 16) & 0xff, ($code >> 8) & 0xff, $code & 0xff);
+	}
+
+	public static function fromARGB(int $code): Color{
+		return new Color(($code >> 16) & 0xff, ($code >> 8) & 0xff, $code & 0xff, ($code >> 24) & 0xff);
+	}
+
+	public function toARGB(): int{
+		return ($this->alpha << 24) | ($this->red << 16) | ($this->green << 8) | $this->blue;
+	}
+
+	public function toBGRA(): int{
+		return ($this->blue << 24) | ($this->green << 16) | ($this->red << 8) | $this->alpha;
+	}
+
+	public function toRGBA(): int{
+		return ($this->red << 24) | ($this->green << 16) | ($this->blue << 8) | $this->alpha;
+	}
+
+	public function toABGR(): int{
+		return ($this->alpha << 24) | ($this->blue << 16) | ($this->green << 8) | $this->red;
+	}
+
 	public function getColorCode(){
 		return ($this->red << 16 | $this->green << 8 | $this->blue) & 0xffffff;
 	}
-
-	/**
-	 * @return string
-	 */
-	public function __toString(){
-		return "Color(red:" . $this->red . ", green:" . $this->green . ", blue:" . $this->blue . ")";
+	
+	public function __toString(): string{
+		return "Color(Red:" . $this->red . ", Green:" . $this->green . ", Blue:" . $this->blue . ", Alpha:" . $this->alpha . ")";
+	}
+	
+	// Leveryl Exclusive Functions (HTML Hex Code Operations)
+	public static function validateHTMLColor(string $hex): bool{
+		return preg_match('/^#[a-f0-9]{6}$/i', $hex);
+	}
+	
+	public static function fromHTMLColor(string $hex): Color{
+		if(!Color::validateHTMLColor($hex)){
+			return new Color(0, 0, 0); // IMPORTANT! : Invalid Hex Code will return BLACK
+		}
+		list($r, $g, $b) = sscanf($hex, "#%02x%02x%02x");
+		return new Color($r, $g, $b);
+	}
+	
+	public function toHTMLColor(): string{
+		return sprintf("#%02x%02x%02x", $this->getRed(), $this->getGreen(), $this->getBlue());
 	}
 }


### PR DESCRIPTION
### Purpose and Effect of This Pull Request
Title and Commit message says it all... :)
1. Adds Alpha (Transparency) to Color object
2. Adds the missing functions

This is ported from (a local dev build of) Leveryl as it's compatible on both PMMP and Genisys based server softwares

### Testing
I just used this on my "TESTERPLUGIN":
```php
case "thtml":
	switch($args[1]){
		case "tohtml":
			$color = Color::getRGB($args[2], $args[3], $args[4]);
			$sender->sendMessage($color->toHTMLColor());
			break;
		case "frhtml":
			$color = Color::fromHTMLColor($args[2]);
			$r = $color->getRed();
			$g = $color->getGreen();
			$b = $color->getBlue();
			$sender->sendMessage($args[2] . " -> " . $r . " " . $g . " " . $b);
			break;
		case "vahtml":
			$sender->sendMessage(strval(Color::validateHTMLColor($args[2])));
			break;
	}
break;
```
#### Invalid HTML Code SHOULD Return Black or R: 0 G: 0 B: 0
If the HTML Code is valid, executing vahtml <HTML Code> should return 1 or 0 (because of strval)

### Fixes
 - This fixes issue #1100 

Note to other GenisysPro developers, Please read the commit comment :) (This is regarding the Code cleanup)